### PR TITLE
Fixed responses when user not in a group

### DIFF
--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/ClusterController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/ClusterController.java
@@ -27,9 +27,6 @@ public class ClusterController {
     GroupClusterRepository groupClusterRepository;
     @Autowired
     GroupRepository groupRepository;
-    @Autowired
-    GroupUserRepository groupUserRepository;
-
 
     @Autowired
     private ClusterUtil clusterUtil;

--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/GroupFeedbackController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/GroupFeedbackController.java
@@ -223,8 +223,8 @@ public class GroupFeedbackController {
         List<GroupFeedbackJsonWithProject> grades = new ArrayList<>();
         for (ProjectEntity project : projects) {
             Long GroupId = groupRepository.groupIdByProjectAndUser(project.getId(), user.getId());
-            if (GroupId == null) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("You are not part of this course");
+            if (GroupId == null) { // Student not yet in a group for this project
+              grades.add(entityToJsonConverter.groupFeedbackEntityToJsonWithProject(null, project));
             }
             CheckResult<GroupFeedbackEntity> checkResult = groupFeedbackUtil.getGroupFeedbackIfExists(GroupId, project.getId());
             if (checkResult.getStatus() != HttpStatus.OK) {

--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/UserController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
     }
 
 
-    @GetMapping(ApiRoutes.USER_AUTH_PATH)
+    @GetMapping(ApiRoutes.USER_BASE_PATH)
     @Roles({UserRole.student, UserRole.teacher})
     public ResponseEntity<Object> getUserByAzureId(Auth auth) {
         UserEntity res = auth.getUserEntity();

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/UserJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/UserJson.java
@@ -87,7 +87,7 @@ public class UserJson {
     public void setUrl(String s){}
 
     public String getCourseUrl() {
-        return ApiRoutes.USER_BASE_PATH + "/" + id+"/courses";
+        return ApiRoutes.COURSE_BASE_PATH;
     }
     public void setCourseUrl(String s){}
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
@@ -174,7 +174,11 @@ public class EntityToJsonConverter {
         Long groupId = groupRepository.groupIdByProjectAndUser(project.getId(), user.getId());
 
         if (courseUserEntity.getRelation() == CourseRelation.enrolled) {
-            submissionUrl += "/" + groupId;
+            if (groupId == null) {
+                submissionUrl = null;
+            } else {
+                submissionUrl += "/" + groupId;
+            }
         }
 
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/SubmissionUtil.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/SubmissionUtil.java
@@ -69,11 +69,15 @@ public class SubmissionUtil {
      * @return CheckResult with the status of the check and the group id
      */
     public CheckResult<Long> checkOnSubmit(long projectId, UserEntity user) {
-        Long groupId = groupRepository.groupIdByProjectAndUser(projectId, user.getId());
-
         if (!projectUtil.userPartOfProject(projectId, user.getId())) {
             return new CheckResult<>(HttpStatus.FORBIDDEN, "You aren't part of this project", null);
         }
+
+        Long groupId = groupRepository.groupIdByProjectAndUser(projectId, user.getId());
+        if (groupId == null) {
+            return new CheckResult<>(HttpStatus.BAD_REQUEST, "User is not part of a group for this project", null);
+        }
+
 
         CheckResult<ProjectEntity> projectCheck = projectUtil.getProjectIfExists(projectId);
         if (projectCheck.getStatus() != HttpStatus.OK) {


### PR DESCRIPTION
### Probleem:
Er werd eigenlijk vanuit gegaan in de backend dat een user sowieso in een groep zit voor een project. Indien dit niet het geval is werd soms teveel informatie volledig achtergehouden (bv. een project als 'null' in de oplijsting van projecten). Dit is niet de bedoeling. Ik ben daarom eens door alle repository methoden gegaan die hier mee te maken hebben, hier een overzicht van wat ik heb aangepast (lijnnummers zullen niet meer 100% kloppen aangezien ik aanpassingen heb gedaan):

**Methode: groupRepository.groupIdByProjectAndUser**
Groupfeebbackcontroller (225) -> aangepast dat indien je nog niet een group zit de groupfeedback nu null is, een ander geval waar dit soms null was is als er gewoon nog geen feedback is gegeven. Er is via deze route dus geen manier om te weten welke van de 2 redenen de oorzaak is. Lemme know als dit toch nuttig kan zijn dan kunnen we eventueel voor een oplossing zoeken

EntityToJsonConverter (128)  -> Dit is wanneer een project terug gegeven wordt met de status. Voorlopig waren de 3 mogelijke strings: "not started", "correct", "incorrect". Hier heb ik aan toegevoegd "no group".

EntityToJsonConverter (167) -> deze staat in dezelfde methode als 175 en was dus dubbel, nu staat er eentje op lijn 168

EntityToJsonConverter (175) -> Dit wordt gewoon meegegeven in de response. De frontend moet hier dus wel rekening mee houden dat dit mogelijks null kan zijn. (Dit is ook null indien een admin/teacher). 
Het wordt echter ook gebruik om de submissionUrl te maken indien de user 'enrolled' is. Deze zal nu dus ook null zijn indien de user nog niet in groep zit. Hier moet dus ook in de frontend op gelet worden 

SubmissionUtil (72) -> Hier een check toegevoegd dat het groupId niet null is. Indien dit wel zo is wordt er een responseEntity terug gegeven met status "HttpStatus.BAD_REQUEST" en body "User is not part of a group for this project" 
(2 testen)

**Methode: groupRepository.userInGroup**
GroupUtil.canAddUserToGroup 
GroupUtil.canRemoveUserFromGroup
GroupUtil.canGetProjectGroupData
-> Alle checks in bovenstaande methoden moeten falen indien de user niet in een group dus hier hoeft niets aan te veranderen
(3 testen)

**Methode: groupRepository.groupByClusterAndUser**
dit wordt maar op 1 plek gebruikt ivm met het verwijderen van de individuele cluster en daar hoort een user altijd in te zitten.

**Methode: GroupClusterRepository.userInGroupForCluster**
Dit wordt maar op 1 plek gebruiktk indien een user een group wil joinen om te checken dat hij niet al in een andere groep zit dus lijkt me ok

### Extra fixes
* Indien de testUrl v/e project werd opgesteld voor een project dat nog geen testen heeft werd toch een url opgebouwd (`/api/tests/null`). Nu is dit veldje van de response gewoon `null`
* Sommige URLs van de user gebruikten `USER_AUTH_PATH` ipv `USER_BASE_PATH`
* De url naar de courses in een userjson response had nog userid etc. in de link, is nu veranderd naar `courses` 