### PR TITLE
Backend users call with query

### DIFF
--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/ApiRoutes.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/ApiRoutes.java
@@ -1,12 +1,12 @@
 package com.ugent.pidgeon.controllers;
 
 public final class ApiRoutes {
-    public static final String USER_BASE_PATH = "/api/users";
+    public static final String USERS_BASE_PATH = "/api/users";
     public static final String COURSE_BASE_PATH = "/api/courses";
     public static final String DEADLINE_BASE_PATH = "/api/deadlines";
     public static final String PROJECT_BASE_PATH = "/api/projects";
 
-
+    public static final String LOGGEDIN_USER_PATH = "/api/user";
     public static final String SUBMISSION_BASE_PATH = "/api/submissions";
 
     public static final String TEST_BASE_PATH = "/api/tests";

--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/ClusterController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/ClusterController.java
@@ -27,9 +27,6 @@ public class ClusterController {
     GroupClusterRepository groupClusterRepository;
     @Autowired
     GroupRepository groupRepository;
-    @Autowired
-    GroupUserRepository groupUserRepository;
-
 
     @Autowired
     private ClusterUtil clusterUtil;

--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/GroupFeedbackController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/GroupFeedbackController.java
@@ -223,8 +223,8 @@ public class GroupFeedbackController {
         List<GroupFeedbackJsonWithProject> grades = new ArrayList<>();
         for (ProjectEntity project : projects) {
             Long GroupId = groupRepository.groupIdByProjectAndUser(project.getId(), user.getId());
-            if (GroupId == null) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).body("You are not part of this course");
+            if (GroupId == null) { // Student not yet in a group for this project
+              grades.add(entityToJsonConverter.groupFeedbackEntityToJsonWithProject(null, project));
             }
             CheckResult<GroupFeedbackEntity> checkResult = groupFeedbackUtil.getGroupFeedbackIfExists(GroupId, project.getId());
             if (checkResult.getStatus() != HttpStatus.OK) {

--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/UserController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
     }
 
 
-    @GetMapping(ApiRoutes.USER_AUTH_PATH)
+    @GetMapping(ApiRoutes.USER_BASE_PATH)
     @Roles({UserRole.student, UserRole.teacher})
     public ResponseEntity<Object> getUserByAzureId(Auth auth) {
         UserEntity res = auth.getUserEntity();

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/UserJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/UserJson.java
@@ -81,7 +81,7 @@ public class UserJson {
     }
 
     public String getUrl() {
-        return ApiRoutes.USER_BASE_PATH + "/" + id;
+        return ApiRoutes.USERS_BASE_PATH + "/" + id;
     }
 
     public void setUrl(String s){}

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/UserJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/UserJson.java
@@ -87,7 +87,7 @@ public class UserJson {
     public void setUrl(String s){}
 
     public String getCourseUrl() {
-        return ApiRoutes.USER_BASE_PATH + "/" + id+"/courses";
+        return ApiRoutes.COURSE_BASE_PATH;
     }
     public void setCourseUrl(String s){}
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/UserRepository.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/UserRepository.java
@@ -15,6 +15,14 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
+    @Query(value = "SELECT u FROM UserEntity u WHERE lower(u.email) = lower(?1)")
+    UserEntity findByEmail(String email);
+
+    @Query(value = "SELECT u FROM UserEntity u WHERE lower(u.name) LIKE concat('%', lower(?1), '%') AND lower(u.surname) LIKE concat('%', lower(?2), '%')")
+    List<UserEntity> findByName(String name, String surname);
+
+
+
 
     public interface CourseWithRelation {
         CourseEntity getCourse();
@@ -34,8 +42,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @Query(value = "SELECT c as course, cu.relation as relation FROM CourseEntity c JOIN CourseUserEntity cu ON c.id = cu.courseId WHERE cu.userId = ?1")
     List<CourseWithRelation> findCoursesByUserId(long id);
 
-    @Query(value = "SELECT * FROM users WHERE azure_id = ?1", nativeQuery = true)
+    @Query(value = "SELECT u FROM UserEntity u WHERE u.azureId = ?1")
     public Optional<UserEntity> findUserByAzureId(String id);
+
+
 
 
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
@@ -174,7 +174,11 @@ public class EntityToJsonConverter {
         Long groupId = groupRepository.groupIdByProjectAndUser(project.getId(), user.getId());
 
         if (courseUserEntity.getRelation() == CourseRelation.enrolled) {
-            submissionUrl += "/" + groupId;
+            if (groupId == null) {
+                submissionUrl = null;
+            } else {
+                submissionUrl += "/" + groupId;
+            }
         }
 
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/SubmissionUtil.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/SubmissionUtil.java
@@ -69,11 +69,15 @@ public class SubmissionUtil {
      * @return CheckResult with the status of the check and the group id
      */
     public CheckResult<Long> checkOnSubmit(long projectId, UserEntity user) {
-        Long groupId = groupRepository.groupIdByProjectAndUser(projectId, user.getId());
-
         if (!projectUtil.userPartOfProject(projectId, user.getId())) {
             return new CheckResult<>(HttpStatus.FORBIDDEN, "You aren't part of this project", null);
         }
+
+        Long groupId = groupRepository.groupIdByProjectAndUser(projectId, user.getId());
+        if (groupId == null) {
+            return new CheckResult<>(HttpStatus.BAD_REQUEST, "User is not part of a group for this project", null);
+        }
+
 
         CheckResult<ProjectEntity> projectCheck = projectUtil.getProjectIfExists(projectId);
         if (projectCheck.getStatus() != HttpStatus.OK) {


### PR DESCRIPTION
## ❗ Veranderd ❗
De route om nu de informatie van de huidig ingelogde user te verkregen is `/api/user` ipv `/api/users` (geen 's' meer op het einde). Kan degene die deze PR reviewed zeker nagaan dat dit nergens in de frontend verandert moet worden?

## Toegevoegd 😎
Er is nu een nieuwe route `/api/users?name=...&surname=...&email=...`
* Email heeft de hoogste priority: dus de zoekquery in de database gebeurt op basis van email, maar indien name & surname ook meegegeven worden zal de user met die email enkel teruggegeven worden indien de naam & surname ook matchen
* Een email wordt niet gechecked of het een juiste email (dus met @ teken etc.) is aangezien er normaal enkel juiste emails id database zitten dus bv. 'kaas' nooit gematched zal worden. Kzou hier in de frontend wel een check voor maken
* Indien email niet wordt meegegeven moet surname of name >=3 letters hebben. Kzou hier ook in de frontend een check voor toevoegen 
* Het matchen van een email/naam/surname gebeurt case insensitive en bij de naam/surname moet de string gewoon ergens in de naam voorkomen. Bv: `/api/users?name=nti` zal een user met naam `Inti` ook teruggeven
* Indien er geen match gevonden is/geen paramaters meegegeven worden/geen email en naam/surname niet >= 3 characters wordt altijd gewoon een lege ~string~ array gereturned. Ik kan dit ook altijd aanpassen indien nodig
