### PR TITLE
Backendadditions

### DIFF
--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/GroupMemberController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/GroupMemberController.java
@@ -15,6 +15,7 @@ import com.ugent.pidgeon.util.UserUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -45,6 +46,7 @@ public class GroupMemberController {
      */
     @DeleteMapping(ApiRoutes.GROUP_MEMBER_BASE_PATH + "/{memberid}")
     @Roles({UserRole.teacher, UserRole.student})
+    @Transactional
     public ResponseEntity<String> removeMemberFromGroup(@PathVariable("groupid") long groupId, @PathVariable("memberid") long memberid, Auth auth) {
         UserEntity user = auth.getUserEntity();
         CheckResult<Void> check = groupUtil.canRemoveUserFromGroup(groupId, memberid, user);

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseJoinInformationJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseJoinInformationJson.java
@@ -1,0 +1,28 @@
+package com.ugent.pidgeon.model.json;
+
+public class CourseJoinInformationJson {
+    private String name;
+    private String description;
+
+    public CourseJoinInformationJson(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseJson.java
@@ -6,9 +6,12 @@ public class CourseJson{
 
     private String description;
 
-    public CourseJson(String name, String description) {
+    private Boolean isArchived;
+
+    public CourseJson(String name, String description, Boolean isArchived) {
         this.name = name;
         this.description = description;
+        this.isArchived = isArchived;
     }
 
     public String getName() {
@@ -25,6 +28,14 @@ public class CourseJson{
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public Boolean getArchived() {
+        return isArchived;
+    }
+
+    public void setArchived(Boolean isArchived) {
+        this.isArchived = isArchived;
     }
 }
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseReferenceJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseReferenceJson.java
@@ -1,19 +1,19 @@
 package com.ugent.pidgeon.model.json;
 
+import java.time.OffsetDateTime;
+
 public class CourseReferenceJson {
     private String name;
     private String url;
     private Long courseId;
-    private Integer memberCount;
-    private Boolean archived;
+    private OffsetDateTime archivedAt;
 
-    public CourseReferenceJson(String name, String url, Long courseId, Integer memberCount,
-        Boolean archived) {
+    public CourseReferenceJson(String name, String url, Long courseId,
+        OffsetDateTime archived) {
         this.name = name;
         this.url = url;
         this.courseId = courseId;
-        this.memberCount = memberCount;
-        this.archived = archived;
+        this.archivedAt = archived;
     }
 
     public String getName() {
@@ -40,19 +40,11 @@ public class CourseReferenceJson {
         this.courseId = courseId;
     }
 
-    public Integer getMemberCount() {
-        return memberCount;
+    public OffsetDateTime getArchivedAt() {
+        return archivedAt;
     }
 
-    public void setMemberCount(Integer memberCount) {
-        this.memberCount = memberCount;
-    }
-
-    public Boolean getArchived() {
-        return archived;
-    }
-
-    public void setArchived(Boolean archived) {
-        this.archived = archived;
+    public void setArchivedAt(OffsetDateTime archivedAt) {
+        this.archivedAt = archivedAt;
     }
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseReferenceJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseReferenceJson.java
@@ -4,11 +4,13 @@ public class CourseReferenceJson {
     private String name;
     private String url;
     private Long courseId;
+    private Integer memberCount;
 
-    public CourseReferenceJson(String name, String url, Long courseId) {
+    public CourseReferenceJson(String name, String url, Long courseId, Integer memberCount) {
         this.name = name;
         this.url = url;
         this.courseId = courseId;
+      this.memberCount = memberCount;
     }
 
     public String getName() {
@@ -33,5 +35,13 @@ public class CourseReferenceJson {
 
     public void setCourseId(Long courseId) {
         this.courseId = courseId;
+    }
+
+    public Integer getMemberCount() {
+        return memberCount;
+    }
+
+    public void setMemberCount(Integer memberCount) {
+        this.memberCount = memberCount;
     }
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseReferenceJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseReferenceJson.java
@@ -5,12 +5,15 @@ public class CourseReferenceJson {
     private String url;
     private Long courseId;
     private Integer memberCount;
+    private Boolean archived;
 
-    public CourseReferenceJson(String name, String url, Long courseId, Integer memberCount) {
+    public CourseReferenceJson(String name, String url, Long courseId, Integer memberCount,
+        Boolean archived) {
         this.name = name;
         this.url = url;
         this.courseId = courseId;
-      this.memberCount = memberCount;
+        this.memberCount = memberCount;
+        this.archived = archived;
     }
 
     public String getName() {
@@ -43,5 +46,13 @@ public class CourseReferenceJson {
 
     public void setMemberCount(Integer memberCount) {
         this.memberCount = memberCount;
+    }
+
+    public Boolean getArchived() {
+        return archived;
+    }
+
+    public void setArchived(Boolean archived) {
+        this.archived = archived;
     }
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithInfoJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithInfoJson.java
@@ -10,6 +10,7 @@ public record CourseWithInfoJson (
         List<UserReferenceJson> assistants,
         String memberUrl,
         String joinUrl,
-        String joinKey
+        String joinKey,
+        Boolean archived
 ) {}
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithInfoJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithInfoJson.java
@@ -1,5 +1,6 @@
 package com.ugent.pidgeon.model.json;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public record CourseWithInfoJson (
@@ -11,6 +12,6 @@ public record CourseWithInfoJson (
         String memberUrl,
         String joinUrl,
         String joinKey,
-        Boolean archived
+        OffsetDateTime archivedAt
 ) {}
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithInfoJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithInfoJson.java
@@ -9,6 +9,7 @@ public record CourseWithInfoJson (
         UserReferenceJson teacher,
         List<UserReferenceJson> assistants,
         String memberUrl,
-        String joinUrl
+        String joinUrl,
+        String joinKey
 ) {}
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithRelationJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithRelationJson.java
@@ -6,6 +6,7 @@ public class CourseWithRelationJson {
     private Long courseId;
     private String url;
     private String name;
+    private Boolean archived;
 
 
     public String getUrl() {
@@ -16,14 +17,17 @@ public class CourseWithRelationJson {
         this.url = url;
     }
 
-    public CourseWithRelationJson() {
+    public CourseWithRelationJson(Boolean archived) {
+      this.archived = archived;
     }
 
-    public CourseWithRelationJson(String url, CourseRelation relation, String name, Long courseId) {
+    public CourseWithRelationJson(String url, CourseRelation relation, String name, Long courseId,
+        Boolean archived) {
         this.url = url;
         this.relation = relation;
         this.name = name;
         this.courseId = courseId;
+        this.archived = archived;
     }
 
     private CourseRelation relation;
@@ -50,5 +54,13 @@ public class CourseWithRelationJson {
 
     public void setCourseId(Long id) {
         this.courseId = id;
+    }
+
+    public Boolean getArchived() {
+        return archived;
+    }
+
+    public void setArchived(Boolean archived) {
+        this.archived = archived;
     }
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithRelationJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/CourseWithRelationJson.java
@@ -1,12 +1,16 @@
 package com.ugent.pidgeon.model.json;
 
 import com.ugent.pidgeon.postgre.models.types.CourseRelation;
+import java.time.OffsetDateTime;
 
 public class CourseWithRelationJson {
     private Long courseId;
     private String url;
     private String name;
-    private Boolean archived;
+    private OffsetDateTime archivedAt;
+    private CourseRelation relation;
+    private Integer memberCount;
+
 
 
     public String getUrl() {
@@ -17,20 +21,17 @@ public class CourseWithRelationJson {
         this.url = url;
     }
 
-    public CourseWithRelationJson(Boolean archived) {
-      this.archived = archived;
-    }
 
     public CourseWithRelationJson(String url, CourseRelation relation, String name, Long courseId,
-        Boolean archived) {
+        OffsetDateTime archivedAt, Integer memberCount) {
         this.url = url;
         this.relation = relation;
         this.name = name;
         this.courseId = courseId;
-        this.archived = archived;
+        this.archivedAt = archivedAt;
+        this.memberCount = memberCount;
     }
 
-    private CourseRelation relation;
 
     public CourseRelation getRelation() {
         return relation;
@@ -56,11 +57,19 @@ public class CourseWithRelationJson {
         this.courseId = id;
     }
 
-    public Boolean getArchived() {
-        return archived;
+    public OffsetDateTime getArchivedAt() {
+        return archivedAt;
     }
 
-    public void setArchived(Boolean archived) {
-        this.archived = archived;
+    public void setArchivedAt(OffsetDateTime archivedAt) {
+        this.archivedAt = archivedAt;
+    }
+
+    public Integer getMemberCount() {
+        return memberCount;
+    }
+
+    public void setMemberCount(Integer memberCount) {
+        this.memberCount = memberCount;
     }
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/postgre/models/CourseEntity.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/postgre/models/CourseEntity.java
@@ -21,6 +21,9 @@ public class CourseEntity {
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
 
+    @Column(name = "archived_at")
+    private OffsetDateTime archivedAt;
+
     public String getJoinKey() {
         return joinKey;
     }
@@ -74,5 +77,13 @@ public class CourseEntity {
 
     public void setCreatedAt(OffsetDateTime createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getArchivedAt() {
+        return archivedAt;
+    }
+
+    public void setArchivedAt(OffsetDateTime archivedAt) {
+        this.archivedAt = archivedAt;
     }
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/CourseUserRepository.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/CourseUserRepository.java
@@ -47,4 +47,11 @@ public interface CourseUserRepository extends JpaRepository<CourseUserEntity, Co
 
     Optional<CourseUserEntity> findByCourseIdAndUserId(long courseId, long userId);
 
+    @Query(value = """
+        SELECT COUNT(*) AS entry_count
+        FROM CourseUserEntity cu
+        WHERE cu.courseId = :courseId
+    """)
+    int countUsersInCourse(long courseId);
+
 }

--- a/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/GroupClusterRepository.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/GroupClusterRepository.java
@@ -31,6 +31,15 @@ public interface GroupClusterRepository extends JpaRepository<GroupClusterEntity
 
     @Query(value = """
     SELECT CASE WHEN EXISTS (
+    	SELECT gc.id FROM GroupClusterEntity gc 
+    	JOIN CourseEntity c ON gc.courseId = c.id
+    	WHERE gc.id = ?1 AND c.archivedAt IS NOT NULL
+    ) THEN true ELSE false END
+    """)
+    Boolean inArchivedCourse(long clusterId);
+
+    @Query(value = """
+    SELECT CASE WHEN EXISTS (
     	SELECT g.id FROM GroupEntity g 
     	JOIN GroupUserEntity gu ON g.id = gu.groupId
     	WHERE gu.userId = ?2 AND g.clusterId = ?1

--- a/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/ProjectRepository.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/ProjectRepository.java
@@ -20,12 +20,9 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, Long> {
 
     @Query(value = """
             SELECT CASE WHEN EXISTS (
-                SELECT gu
-                FROM GroupUserEntity gu
-                INNER JOIN GroupEntity g ON gu.groupId = g.id
-                INNER JOIN GroupClusterEntity gc ON g.clusterId = gc.id
-                INNER JOIN ProjectEntity p ON p.groupClusterId = gc.id
-                WHERE gu.userId = ?2 and p.id = ?1
+                SELECT p FROM CourseUserEntity cu
+                INNER JOIN ProjectEntity p ON p.courseId = cu.courseId
+                WHERE cu.userId = ?2 and p.id = ?1
             ) THEN true ELSE false END""")
     Boolean userPartOfProject(long projectId, long userId);
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/UserRepository.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/postgre/repository/UserRepository.java
@@ -35,8 +35,19 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
         String getName();
     }
 
-    @Query(value = "SELECT c.id as courseId, cu.relation as relation, c.name as name FROM CourseEntity c JOIN CourseUserEntity cu ON c.id = cu.courseId WHERE cu.userId = ?1")
+    @Query(value = """
+        SELECT c.id as courseId, cu.relation as relation, c.name as name
+        FROM CourseEntity c JOIN CourseUserEntity cu ON c.id = cu.courseId
+        WHERE cu.userId = ?1 AND c.archivedAt IS NULL
+        """)
     List<CourseIdWithRelation> findCourseIdsByUserId(long id);
+
+    @Query(value = """
+        SELECT c.id as courseId, cu.relation as relation, c.name as name
+        FROM CourseEntity c JOIN CourseUserEntity cu ON c.id = cu.courseId
+        WHERE cu.userId = ?1 AND c.archivedAt IS NOT NULL
+        """)
+    List<CourseIdWithRelation> findArchivedCoursesByUserId(long id);
 
     /* The 'as' is important here, as it is used to map the result to the CourseWithRelation interface */
     @Query(value = "SELECT c as course, cu.relation as relation FROM CourseEntity c JOIN CourseUserEntity cu ON c.id = cu.courseId WHERE cu.userId = ?1")

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/ClusterUtil.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/ClusterUtil.java
@@ -24,7 +24,7 @@ public class ClusterUtil {
      * @return true if the cluster is an individual cluster
      */
     public boolean isIndividualCluster(GroupClusterEntity cluster) {
-        return cluster != null && cluster.getGroupAmount() <= 1;
+        return (cluster != null && cluster.getMaxSize() <= 1);
     }
 
     /**

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/CommonDatabaseActions.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/CommonDatabaseActions.java
@@ -63,19 +63,19 @@ public class CommonDatabaseActions {
      * @param userId id of the user
      * @return true if the group was created successfully
      */
-    public boolean createNewIndividualClusterGroup(long courseId, long userId) {
+    public boolean createNewIndividualClusterGroup(long courseId, UserEntity user) {
         GroupClusterEntity groupClusterEntity = groupClusterRepository.findIndividualClusterByCourseId(courseId).orElse(null);
         if (groupClusterEntity == null) {
             return false;
         }
         // Create new group for the cluster
-        GroupEntity groupEntity = new GroupEntity("", groupClusterEntity.getId());
+        GroupEntity groupEntity = new GroupEntity(user.getName() + " " + user.getSurname(), groupClusterEntity.getId());
         groupClusterEntity.setGroupAmount(groupClusterEntity.getGroupAmount() + 1);
         groupClusterRepository.save(groupClusterEntity);
         groupEntity = groupRepository.save(groupEntity);
 
         // Add user to the group
-        GroupUserEntity groupUserEntity = new GroupUserEntity(groupEntity.getId(), userId);
+        GroupUserEntity groupUserEntity = new GroupUserEntity(groupEntity.getId(), user.getId());
         groupUserRepository.save(groupUserEntity);
         return true;
     }

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/CourseUtil.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/CourseUtil.java
@@ -242,7 +242,20 @@ public class CourseUtil {
      * @param courseJson json with the course data
      * @return CheckResult with the status of the check
      */
-    public CheckResult<Void> checkCourseJson(CourseJson courseJson) {
+    public CheckResult<Void> checkCourseJson(CourseJson courseJson, UserEntity user, Long courseId) {
+        // If the courseId is null we are creating a course
+        if (courseId != null) {
+            CourseUserEntity courseUserEntity = courseUserRepository.findById(new CourseUserId(courseId, user.getId())).orElse(null);
+            if (courseUserEntity == null) {
+                return new CheckResult<>(HttpStatus.FORBIDDEN, "User is not part of the course", null);
+            }
+
+            if (courseJson.getArchived() != null && !courseUserEntity.getRelation().equals(CourseRelation.creator)) {
+                return new CheckResult<>(HttpStatus.FORBIDDEN, "Only the course creator can (un)archive the course", null);
+            }
+        }
+
+
         if (courseJson.getName() == null || courseJson.getDescription() == null) {
             return new CheckResult<>(HttpStatus.BAD_REQUEST, "name and description are required", null);
         }

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/CourseUtil.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/CourseUtil.java
@@ -148,9 +148,13 @@ public class CourseUtil {
         if (courseCheck.getStatus() != HttpStatus.OK) {
             return new CheckResult<>(courseCheck.getStatus(), courseCheck.getMessage(), null);
         }
+        CourseEntity course = courseCheck.getData().getFirst();
         CourseRelation relation = courseCheck.getData().getSecond();
         if (relation.equals(CourseRelation.creator)) {
             return new CheckResult<>(HttpStatus.BAD_REQUEST, "Cannot leave a course you created", null);
+        }
+        if (course.getArchivedAt() != null) {
+            return new CheckResult<>(HttpStatus.BAD_REQUEST, "Cannot leave an archived course", null);
         }
         return new CheckResult<>(HttpStatus.OK, "", relation);
     }

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
@@ -92,7 +92,8 @@ public class EntityToJsonConverter {
                 assistantsJson,
                 ApiRoutes.COURSE_BASE_PATH + "/" + course.getId() + "/members",
                 hideKey ? null : joinLink,
-                hideKey ? null : course.getJoinKey()
+                hideKey ? null : course.getJoinKey(),
+                course.getArchivedAt() != null
         );
     }
 
@@ -101,7 +102,8 @@ public class EntityToJsonConverter {
                 ApiRoutes.COURSE_BASE_PATH + "/" + course.getId(),
                 relation,
                 course.getName(),
-                course.getId()
+                course.getId(),
+            course.getArchivedAt() != null
         );
     }
 
@@ -204,7 +206,8 @@ public class EntityToJsonConverter {
             course.getName(),
             ApiRoutes.COURSE_BASE_PATH + "/" + course.getId(),
             course.getId(),
-            memberCount
+            memberCount,
+            course.getArchivedAt() != null
         );
     }
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
@@ -77,7 +77,7 @@ public class EntityToJsonConverter {
         return new UserReferenceWithRelation(userEntityToUserReference(user), relation.toString());
     }
 
-    public CourseWithInfoJson courseEntityToCourseWithInfo(CourseEntity course, String joinLink) {
+    public CourseWithInfoJson courseEntityToCourseWithInfo(CourseEntity course, String joinLink, boolean hideKey) {
         UserEntity teacher = courseRepository.findTeacherByCourseId(course.getId());
         UserReferenceJson teacherJson = userEntityToUserReference(teacher);
 
@@ -91,7 +91,8 @@ public class EntityToJsonConverter {
                 teacherJson,
                 assistantsJson,
                 ApiRoutes.COURSE_BASE_PATH + "/" + course.getId() + "/members",
-                joinLink
+                hideKey ? null : joinLink,
+                hideKey ? null : course.getJoinKey()
         );
     }
 
@@ -183,7 +184,7 @@ public class EntityToJsonConverter {
 
 
         return new ProjectResponseJson(
-                new CourseReferenceJson(course.getName(), ApiRoutes.COURSE_BASE_PATH + "/" + course.getId(), course.getId()),
+                courseEntityToCourseReference(course),
                 project.getDeadline(),
                 project.getDescription(),
                 project.getId(),
@@ -196,6 +197,18 @@ public class EntityToJsonConverter {
                 groupId
         );
     }
+
+    public CourseReferenceJson courseEntityToCourseReference(CourseEntity course) {
+        int memberCount = courseUserRepository.countUsersInCourse(course.getId());
+        return new CourseReferenceJson(
+            course.getName(),
+            ApiRoutes.COURSE_BASE_PATH + "/" + course.getId(),
+            course.getId(),
+            memberCount
+        );
+    }
+
+
 
     public SubmissionJson getSubmissionJson(SubmissionEntity submission) {
         return new SubmissionJson(

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/EntityToJsonConverter.java
@@ -93,17 +93,19 @@ public class EntityToJsonConverter {
                 ApiRoutes.COURSE_BASE_PATH + "/" + course.getId() + "/members",
                 hideKey ? null : joinLink,
                 hideKey ? null : course.getJoinKey(),
-                course.getArchivedAt() != null
+                course.getArchivedAt()
         );
     }
 
     public CourseWithRelationJson courseEntityToCourseWithRelation(CourseEntity course, CourseRelation relation) {
+        int memberCount = courseUserRepository.countUsersInCourse(course.getId());
         return new CourseWithRelationJson(
                 ApiRoutes.COURSE_BASE_PATH + "/" + course.getId(),
                 relation,
                 course.getName(),
                 course.getId(),
-            course.getArchivedAt() != null
+                course.getArchivedAt(),
+                memberCount
         );
     }
 
@@ -201,13 +203,11 @@ public class EntityToJsonConverter {
     }
 
     public CourseReferenceJson courseEntityToCourseReference(CourseEntity course) {
-        int memberCount = courseUserRepository.countUsersInCourse(course.getId());
         return new CourseReferenceJson(
             course.getName(),
             ApiRoutes.COURSE_BASE_PATH + "/" + course.getId(),
             course.getId(),
-            memberCount,
-            course.getArchivedAt() != null
+            course.getArchivedAt()
         );
     }
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/util/ProjectUtil.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/util/ProjectUtil.java
@@ -1,17 +1,9 @@
 package com.ugent.pidgeon.util;
 
-import com.ugent.pidgeon.controllers.ApiRoutes;
-import com.ugent.pidgeon.model.ProjectResponseJson;
-import com.ugent.pidgeon.model.json.CourseReferenceJson;
 import com.ugent.pidgeon.model.json.ProjectJson;
-import com.ugent.pidgeon.model.json.ProjectProgressJson;
 import com.ugent.pidgeon.postgre.models.*;
-import com.ugent.pidgeon.postgre.models.types.CourseRelation;
 import com.ugent.pidgeon.postgre.models.types.UserRole;
-import com.ugent.pidgeon.postgre.repository.CourseUserRepository;
-import com.ugent.pidgeon.postgre.repository.GroupRepository;
 import com.ugent.pidgeon.postgre.repository.ProjectRepository;
-import com.ugent.pidgeon.postgre.repository.SubmissionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;

--- a/backend/app/src/test/java/com/ugent/pidgeon/controllers/CourseControllerTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/controllers/CourseControllerTest.java
@@ -117,9 +117,9 @@ public class CourseControllerTest extends ControllerTest {
         when(courseUserRepository.save(any())).thenReturn(null);
         when(groupClusterRepository.save(any())).thenReturn(null);
         when(courseUtil.getJoinLink(any(), any())).thenReturn("");
-        when(entityToJsonConverter.courseEntityToCourseWithInfo(any(), any())).
+        when(entityToJsonConverter.courseEntityToCourseWithInfo(any(), any(), any())).
                 thenReturn(new CourseWithInfoJson(0L, "", "", new UserReferenceJson("", "", 0L),
-                        new ArrayList<>(), "", ""));
+                        new ArrayList<>(), "", "", ""));
 
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -214,9 +214,9 @@ public class CourseControllerTest extends ControllerTest {
     @Test
     public void testGetCourseByCourseId() throws Exception {
         when(courseUtil.getJoinLink(any(), any())).thenReturn("");
-        when(entityToJsonConverter.courseEntityToCourseWithInfo(any(), any())).
+        when(entityToJsonConverter.courseEntityToCourseWithInfo(any(), any(), any())).
                 thenReturn(new CourseWithInfoJson(0L, "", "", new UserReferenceJson("", "", 0L),
-                        new ArrayList<>(), "", ""));
+                        new ArrayList<>(), "", "", ""));
         when(courseUtil.getCourseIfUserInCourse(anyLong(), any(UserEntity.class))).
                 thenReturn(new CheckResult<>(HttpStatus.OK, "", new Pair<>(new CourseEntity(), null)));
         mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.COURSE_BASE_PATH + "/1"))

--- a/backend/app/src/test/java/com/ugent/pidgeon/controllers/CourseControllerTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/controllers/CourseControllerTest.java
@@ -276,7 +276,7 @@ public class CourseControllerTest extends ControllerTest {
                 .thenReturn(new CheckResult<>(HttpStatus.OK, "", new Pair<>(course, CourseRelation.creator)));
         when(projectRepository.findByCourseId(anyLong())).thenReturn(projects);
         when(entityToJsonConverter.projectEntityToProjectResponseJson(any(ProjectEntity.class), any(CourseEntity.class), any(UserEntity.class))).thenReturn(new ProjectResponseJson(
-                new CourseReferenceJson("", "Test Course", 1L),
+                new CourseReferenceJson("", "Test Course", 1L, 0),
                 OffsetDateTime.MIN,
                 "",
                 1L,
@@ -302,11 +302,11 @@ public class CourseControllerTest extends ControllerTest {
         CourseEntity course = new CourseEntity("name", "descripton");
         course.setId(1);
         when(courseUtil.checkJoinLink(anyLong(), any(), any())).thenReturn(new CheckResult<>(HttpStatus.OK, "", course));
-        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), anyLong())).thenReturn(true);
+        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), any())).thenReturn(true);
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH + "/1/join/1908"))
                 .andExpect(status().isOk());
 
-        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), anyLong())).thenReturn(false);
+        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), any())).thenReturn(false);
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH + "/1/join/1908"))
                 .andExpect(status().isInternalServerError());
 
@@ -334,11 +334,11 @@ public class CourseControllerTest extends ControllerTest {
         CourseEntity course = new CourseEntity("name", "descripton");
         course.setId(1);
         when(courseUtil.checkJoinLink(anyLong(), any(), any())).thenReturn(new CheckResult<>(HttpStatus.OK, "", course));
-        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), anyLong())).thenReturn(true);
+        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), any())).thenReturn(true);
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH + "/1/join"))
                 .andExpect(status().isOk());
 
-        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), anyLong())).thenReturn(false);
+        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), any())).thenReturn(false);
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH + "/1/join"))
                 .andExpect(status().isInternalServerError());
     }
@@ -402,14 +402,14 @@ public class CourseControllerTest extends ControllerTest {
         String request = "{\"userId\": 1, \"relation\": \"enrolled\"}";
         when(courseUtil.canUpdateUserInCourse(anyLong(), any(), any(), any())).
                 thenReturn(new CheckResult<>(HttpStatus.OK, "", new CourseUserEntity(1, 1, CourseRelation.enrolled)));
-        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), anyLong()))
+        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), any()))
             .thenReturn(true);
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH + "/1/members")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request))
                 .andExpect(status().isCreated());
 
-        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), anyLong()))
+        when(commonDatabaseActions.createNewIndividualClusterGroup(anyLong(), any()))
             .thenReturn(false);
         mockMvc.perform(MockMvcRequestBuilders.post(ApiRoutes.COURSE_BASE_PATH + "/1/members")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/backend/app/src/test/java/com/ugent/pidgeon/controllers/ProjectControllerTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/controllers/ProjectControllerTest.java
@@ -194,7 +194,7 @@ public class ProjectControllerTest {
     when(auth.getUserEntity()).thenReturn(user);
     when(entityToJsonConverter.projectEntityToProjectResponseJson(project2, courseCheck.getData().getFirst(),
         user)).thenReturn(new ProjectResponseJson(
-        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L),
+        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
         OffsetDateTime.MAX,
         "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
         1L));
@@ -248,7 +248,7 @@ public class ProjectControllerTest {
     when(auth.getUserEntity()).thenReturn(user);
     when(entityToJsonConverter.projectEntityToProjectResponseJson(project2, courseCheck.getData(),
         user)).thenReturn(new ProjectResponseJson(
-        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L),
+        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
         OffsetDateTime.MAX,
         "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
         1L));
@@ -302,7 +302,7 @@ public class ProjectControllerTest {
     when(auth.getUserEntity()).thenReturn(user);
     when(entityToJsonConverter.projectEntityToProjectResponseJson(project2, courseCheck.getData().getFirst(),
         user)).thenReturn(new ProjectResponseJson(
-        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L),
+        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
         OffsetDateTime.MAX,
         "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
         1L));
@@ -563,7 +563,7 @@ public class ProjectControllerTest {
     when(courseRepository.findById(projectId)).thenReturn(Optional.of(courseEntity));
     when(entityToJsonConverter.projectEntityToProjectResponseJson(any(), any(), any())).thenReturn(
         new ProjectResponseJson(
-            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L),
+            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
             OffsetDateTime.MAX,
             "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
             1L));
@@ -610,7 +610,7 @@ public class ProjectControllerTest {
     when(courseRepository.findById(projectId)).thenReturn(Optional.of(courseEntity));
     when(entityToJsonConverter.projectEntityToProjectResponseJson(any(), any(), any())).thenReturn(
         new ProjectResponseJson(
-            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L),
+            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
             OffsetDateTime.MAX,
             "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
             1L));

--- a/backend/app/src/test/java/com/ugent/pidgeon/controllers/ProjectControllerTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/controllers/ProjectControllerTest.java
@@ -194,7 +194,7 @@ public class ProjectControllerTest {
     when(auth.getUserEntity()).thenReturn(user);
     when(entityToJsonConverter.projectEntityToProjectResponseJson(project2, courseCheck.getData().getFirst(),
         user)).thenReturn(new ProjectResponseJson(
-        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
+        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, OffsetDateTime.now()),
         OffsetDateTime.MAX,
         "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
         1L));
@@ -248,7 +248,7 @@ public class ProjectControllerTest {
     when(auth.getUserEntity()).thenReturn(user);
     when(entityToJsonConverter.projectEntityToProjectResponseJson(project2, courseCheck.getData(),
         user)).thenReturn(new ProjectResponseJson(
-        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
+        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, OffsetDateTime.now()),
         OffsetDateTime.MAX,
         "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
         1L));
@@ -302,7 +302,7 @@ public class ProjectControllerTest {
     when(auth.getUserEntity()).thenReturn(user);
     when(entityToJsonConverter.projectEntityToProjectResponseJson(project2, courseCheck.getData().getFirst(),
         user)).thenReturn(new ProjectResponseJson(
-        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
+        new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, OffsetDateTime.now()),
         OffsetDateTime.MAX,
         "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
         1L));
@@ -563,7 +563,7 @@ public class ProjectControllerTest {
     when(courseRepository.findById(projectId)).thenReturn(Optional.of(courseEntity));
     when(entityToJsonConverter.projectEntityToProjectResponseJson(any(), any(), any())).thenReturn(
         new ProjectResponseJson(
-            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
+            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, OffsetDateTime.now()),
             OffsetDateTime.MAX,
             "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
             1L));
@@ -610,7 +610,7 @@ public class ProjectControllerTest {
     when(courseRepository.findById(projectId)).thenReturn(Optional.of(courseEntity));
     when(entityToJsonConverter.projectEntityToProjectResponseJson(any(), any(), any())).thenReturn(
         new ProjectResponseJson(
-            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, 0),
+            new CourseReferenceJson("TestCourse", ApiRoutes.COURSE_BASE_PATH + "/" + 1L, 1L, OffsetDateTime.now()),
             OffsetDateTime.MAX,
             "Test", 2L, "TestProject", "testUrl", "testUrl", 0, true, new ProjectProgressJson(0, 0),
             1L));

--- a/backend/app/src/test/java/com/ugent/pidgeon/controllers/UserControllerTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/controllers/UserControllerTest.java
@@ -47,20 +47,20 @@ public class UserControllerTest extends ControllerTest {
   @Test
   public void testGetUserById() throws Exception {
     when(userUtil.getUserIfExists(anyLong())).thenReturn(userEntity);
-    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USER_BASE_PATH + "/1"))
+    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USERS_BASE_PATH + "/1"))
         .andExpect(status().isOk());
 
     when(userUtil.getUserIfExists(anyLong())).thenReturn(null);
-    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USER_BASE_PATH + "/1"))
+    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USERS_BASE_PATH + "/1"))
         .andExpect(status().isNotFound());
 
-    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USER_BASE_PATH + "/2"))
+    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USERS_BASE_PATH + "/2"))
         .andExpect(status().isForbidden());
   }
 
   @Test
   public void testGetUserByAzureId() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.USER_AUTH_PATH))
+    mockMvc.perform(MockMvcRequestBuilders.get(ApiRoutes.LOGGEDIN_USER_PATH))
         .andExpect(status().isOk());
   }
 
@@ -69,14 +69,14 @@ public class UserControllerTest extends ControllerTest {
     String request = "{\"name\":\"John\",\"surname\":\"Doe\",\"email\":\"john@example.com\",\"role\":\"admin\"}";
     when(userUtil.checkForUserUpdateJson(anyLong(), any())).
         thenReturn(new CheckResult<>(HttpStatus.OK, "", userEntity));
-    mockMvc.perform(MockMvcRequestBuilders.put(ApiRoutes.USER_BASE_PATH + "/1")
+    mockMvc.perform(MockMvcRequestBuilders.put(ApiRoutes.USERS_BASE_PATH + "/1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(request))
         .andExpect(status().isOk());
 
     when(userUtil.checkForUserUpdateJson(anyLong(), any())).
         thenReturn(new CheckResult<>(HttpStatus.BAD_REQUEST, "", null));
-    mockMvc.perform(MockMvcRequestBuilders.put(ApiRoutes.USER_BASE_PATH + "/1")
+    mockMvc.perform(MockMvcRequestBuilders.put(ApiRoutes.USERS_BASE_PATH + "/1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(request))
         .andExpect(status().isBadRequest());
@@ -88,20 +88,20 @@ public class UserControllerTest extends ControllerTest {
     when(userUtil.getUserIfExists(anyLong())).thenReturn(userEntity);
     when(userUtil.checkForUserUpdateJson(anyLong(), any()))
         .thenReturn(new CheckResult<>(HttpStatus.OK, "", userEntity));
-    mockMvc.perform(MockMvcRequestBuilders.patch(ApiRoutes.USER_BASE_PATH + "/1")
+    mockMvc.perform(MockMvcRequestBuilders.patch(ApiRoutes.USERS_BASE_PATH + "/1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(request))
         .andExpect(status().isOk());
 
     when(userUtil.checkForUserUpdateJson(anyLong(), any()))
         .thenReturn(new CheckResult<>(HttpStatus.BAD_REQUEST, "", null));
-    mockMvc.perform(MockMvcRequestBuilders.patch(ApiRoutes.USER_BASE_PATH + "/1")
+    mockMvc.perform(MockMvcRequestBuilders.patch(ApiRoutes.USERS_BASE_PATH + "/1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(request))
         .andExpect(status().isBadRequest());
 
     when(userUtil.getUserIfExists(anyLong())).thenReturn(null);
-    mockMvc.perform(MockMvcRequestBuilders.patch(ApiRoutes.USER_BASE_PATH + "/1")
+    mockMvc.perform(MockMvcRequestBuilders.patch(ApiRoutes.USERS_BASE_PATH + "/1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(request))
         .andExpect(status().isNotFound());

--- a/backend/app/src/test/java/com/ugent/pidgeon/util/CourseUtilTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/util/CourseUtilTest.java
@@ -141,18 +141,18 @@ public class CourseUtilTest {
 
   @Test
   public void testCheckCourseJson() throws Exception {
-    CourseJson courseJson = new CourseJson("name", "description");
-    CheckResult<Void> result = courseUtil.checkCourseJson(courseJson);
+    CourseJson courseJson = new CourseJson("name", "description", null);
+    CheckResult<Void> result = courseUtil.checkCourseJson(courseJson, user, null);
     assertEquals(HttpStatus.OK, result.getStatus());
 
     courseJson.setDescription(null);
-    result = courseUtil.checkCourseJson(courseJson);
+    result = courseUtil.checkCourseJson(courseJson, user, null);
     assertEquals(HttpStatus.BAD_REQUEST, result.getStatus());
     assertEquals("name and description are required", result.getMessage());
 
     courseJson.setDescription("description");
     courseJson.setName("");
-    result = courseUtil.checkCourseJson(courseJson);
+    result = courseUtil.checkCourseJson(courseJson, user, null);
     assertEquals(HttpStatus.BAD_REQUEST, result.getStatus());
     assertEquals("Name cannot be empty", result.getMessage());
   }

--- a/backend/app/src/test/java/com/ugent/pidgeon/util/EntityToJsonConverterTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/util/EntityToJsonConverterTest.java
@@ -118,7 +118,7 @@ public class EntityToJsonConverterTest {
     when(courseRepository.findTeacherByCourseId(anyLong())).thenReturn(userEntity);
     when(courseRepository.findAssistantsByCourseId(anyLong())).thenReturn(Collections.emptyList());
     CourseWithInfoJson result = entityToJsonConverter.courseEntityToCourseWithInfo(courseEntity,
-        "joinLink");
+        "joinLink", false);
     assertEquals(courseEntity.getId(), result.courseId());
     assertEquals(courseEntity.getName(), result.name());
   }

--- a/backend/app/src/test/java/com/ugent/pidgeon/util/GroupUtilTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/util/GroupUtilTest.java
@@ -32,6 +32,8 @@ public class GroupUtilTest {
   private ClusterUtil clusterUtil;
   @Mock
   private ProjectUtil projectUtil;
+  @Mock
+  private UserUtil userUtil;
 
   @InjectMocks
   private GroupUtil groupUtil;
@@ -115,14 +117,19 @@ public class GroupUtilTest {
   @Test
   public void TestCanAddUserToGroup() throws Exception {
     when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
-    when(groupRepository.isAdminOfGroup(1L, user.getId())).thenReturn(true);
+    when(groupRepository.isAdminOfGroup(user.getId(), 1L)).thenReturn(true);
     when(groupClusterRepository.userInGroupForCluster(anyLong(), anyLong())).thenReturn(false);
     when(groupRepository.userInGroup(anyLong(), anyLong())).thenReturn(false);
     when(clusterUtil.getClusterIfExists(group.getClusterId()))
         .thenReturn(new CheckResult<>(HttpStatus.OK, "", groupCluster));
     when(groupRepository.countUsersInGroup(group.getId())).thenReturn(1);
     when(clusterUtil.isIndividualCluster(groupCluster.getId())).thenReturn(false);
-
+    when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+    UserEntity userToAdd = new UserEntity();
+    userToAdd.setId(2L);
+    userToAdd.setRole(UserRole.student);
+    when(userUtil.getUserIfExists(2L)).thenReturn(userToAdd);
+    when(groupRepository.isAdminOfGroup(2L, 1L)).thenReturn(false);
     CheckResult<Void> result = groupUtil.canAddUserToGroup(group.getId(), 2L, user);
     assertEquals(HttpStatus.OK, result.getStatus());
   }

--- a/backend/app/src/test/java/com/ugent/pidgeon/util/SubmissionUtilTest.java
+++ b/backend/app/src/test/java/com/ugent/pidgeon/util/SubmissionUtilTest.java
@@ -1,11 +1,14 @@
 package com.ugent.pidgeon.util;
 
+import com.ugent.pidgeon.postgre.models.GroupEntity;
 import com.ugent.pidgeon.postgre.models.ProjectEntity;
 import com.ugent.pidgeon.postgre.models.SubmissionEntity;
 import com.ugent.pidgeon.postgre.models.UserEntity;
+import com.ugent.pidgeon.postgre.repository.GroupClusterRepository;
 import com.ugent.pidgeon.postgre.repository.GroupRepository;
 import com.ugent.pidgeon.postgre.repository.SubmissionRepository;
 import java.time.OffsetDateTime;
+import org.hibernate.validator.constraints.ModCheck.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +35,9 @@ public class SubmissionUtilTest {
 
   @Mock
   private SubmissionRepository submissionRepository;
+
+  @Mock
+  private GroupClusterRepository groupClusterRepository;
 
   @Mock
   private GroupUtil groupUtil;
@@ -87,6 +93,8 @@ public class SubmissionUtilTest {
     when(groupRepository.groupIdByProjectAndUser(anyLong(), anyLong())).thenReturn(1L);
     when(projectUtil.userPartOfProject(anyLong(), anyLong())).thenReturn(true);
     when(projectUtil.getProjectIfExists(anyLong())).thenReturn(new CheckResult<>(HttpStatus.OK, "", projectEntity));
+    when(groupUtil.getGroupIfExists(anyLong())).thenReturn(new CheckResult<>(HttpStatus.OK, "", new GroupEntity()));
+    when(groupClusterRepository.inArchivedCourse(anyLong())).thenReturn(false);
     assertEquals(1L, submissionUtil.checkOnSubmit(1L, userEntity).getData());
   }
 }

--- a/backend/database/start_database.sql
+++ b/backend/database/start_database.sql
@@ -18,6 +18,7 @@ CREATE TABLE courses (
     course_name VARCHAR(100) NOT NULL,
     description TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    archived_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,
     join_key TEXT
 );
 


### PR DESCRIPTION
## Toevoegingen aan de backend nodig voor de frontend

### [Issue #208](https://github.com/SELab-2/UGent-6/issues/208): 
memberCount

<close #208>

`CourseWithRelation` (wat voorlopig enkel wordt teruggegeven bij `/api/courses` bevat nu een veldje `memberCount` en ziet er als volgt uit:

```json
{
		"courseId": 2,
		"url": "/api/courses/2",
		"name": "TestPatchNAMEWOOP",
		"archivedAt": null,
		"relation": "creator",
		"memberCount": 1
}
```

### [Issue #209](https://github.com/SELab-2/UGent-6/issues/209) joinKey

<close #209>
* JoinKey is toegevoegd aan de reponse v/e een course, zoals dit:
```json
{
	"courseId": 2,
	"name": "Science",
	"description": "Basics of Scientific Method",
	"teacher": {
		"name": "Inti Danschutter",
		"email": "Inti.Danschutter@UGent.be",
		"userId": 1
	},
	"assistants": [],
	"memberUrl": "/api/courses/2/members",
	"joinUrl": "/api/courses/2/join/8fa4c040-a0c5-4305-9e4e-0fb68219b179",
	"joinKey": "8fa4c040-a0c5-4305-9e4e-0fb68219b179"
}
```

* Zowel joinKey als joinUrl velden worden nu gehide voor een student v/e vak (dus in bovenste response zullen deze sowieso `null` zijn voor een student)
	* Enige uitzondering hierop is bij de response wanneer een vak gejoined wordt via de joinlink, aangezien de student deze dan toch sowieso al heeft

* ~`/api/courses/{courseId}/joinLink`~ nu `/api/courses/{courseId}/joinKey` en returned enkel de key ipv de volledige link

### [Issue #210](https://github.com/SELab-2/UGent-6/issues/210) archiveren van projecten

<close #210>

Het archiveren van een vak komt overeen met het op nonactief zetten van dit vak. Dit betekent dat er vanuit een student (`enrolled`) geen optie meer is voor interactie met het vak (groepen joinen/leaven, vak joinen/leaven, indienen).

Enkel een creator kan een course (un)archiven. Dit door een PUT/PATCH met een veld: `archived`(boolean) 

Aanpassingen aan een vak kunnen nog gebeuren wanneer een vak gearchiveerd is. 
* ❓Is het logischer om er voor te zorgen dat enkel de creator nog aanpassingen kan doen op dat moment? Dit is wel nog wat werk (bijna elke route moet overlopen worden) dus kwou eerst second opinion horen 

Bij het opvragen van de courses van de courses `/api/courses` is er nu een parameter: 

 * `/api/courses` geeft alle courses v/e user (zowel archived als niet archived)
* `/api/courses?archived=true` geeft alle gearchiveerde courses v/e user
* `/api/courses?archived=false` geeft alle niet-gearchiveerde courses v/e user

Overal waar een course/verwijzing naar een course wordt teruggegeven wordt nu ook een veld `archivedAt` meegegeven dat de datum van archiven bevat of `null` indien het niet gearchived is

### [Issue #211](https://github.com/SELab-2/UGent-6/issues/211) Individuele groepnamen

<close #211>

De groepen v/e individuele cluster krijgen nu de naam van de user  (ivp `""`) waardoor ze meteen in de frontend gedisplayed kunnen worden.

### Extra
Nog een aantal bugfixes