### PR TITLE
PUT/PATCH/POST routes for test now work with json

### DIFF
--- a/backend/app/src/main/java/com/ugent/pidgeon/controllers/TestController.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/controllers/TestController.java
@@ -3,6 +3,7 @@ package com.ugent.pidgeon.controllers;
 import com.ugent.pidgeon.auth.Roles;
 import com.ugent.pidgeon.model.Auth;
 import com.ugent.pidgeon.model.json.TestJson;
+import com.ugent.pidgeon.model.json.TestUpdateJson;
 import com.ugent.pidgeon.model.submissionTesting.DockerSubmissionTestModel;
 import com.ugent.pidgeon.postgre.models.*;
 import com.ugent.pidgeon.postgre.models.types.UserRole;
@@ -58,37 +59,31 @@ public class TestController {
     @PostMapping(ApiRoutes.PROJECT_BASE_PATH + "/{projectid}/tests")
     @Roles({UserRole.teacher, UserRole.student})
     public ResponseEntity<?> updateTests(
-        @RequestParam(name = "dockerimage", required = false) String dockerImage,
-        @RequestParam(name = "dockerscript", required = false) String dockerTest,
-        @RequestParam(name = "dockertemplate", required = false) String dockerTemplate,
-        @RequestParam(name = "structuretest", required = false) String structureTest,
+        @RequestBody TestUpdateJson testJson,
         @PathVariable("projectid") long projectId,
         Auth auth) {
-        return alterTests(projectId, auth.getUserEntity(), dockerImage, dockerTest,  dockerTemplate,  structureTest, HttpMethod.POST);
+        return alterTests(projectId, auth.getUserEntity(), testJson.getDockerImage(), testJson.getDockerScript(),
+            testJson.getDockerTemplate(), testJson.getStructureTest(), HttpMethod.POST);
     }
 
     @PatchMapping(ApiRoutes.PROJECT_BASE_PATH + "/{projectid}/tests")
     @Roles({UserRole.teacher, UserRole.student})
     public ResponseEntity<?> patchTests(
-        @RequestParam(name = "dockerimage", required = false) String dockerImage,
-        @RequestParam(name = "dockerscript", required = false) String dockerTest,
-        @RequestParam(name = "dockertemplate", required = false) String dockerTemplate,
-        @RequestParam(name = "structuretest", required = false) String structureTest,
+        @RequestBody TestUpdateJson testJson,
         @PathVariable("projectid") long projectId,
         Auth auth) {
-        return alterTests(projectId, auth.getUserEntity(), dockerImage, dockerTest,  dockerTemplate, structureTest, HttpMethod.PATCH);
+        return alterTests(projectId, auth.getUserEntity(), testJson.getDockerImage(), testJson.getDockerScript(),
+            testJson.getDockerTemplate(), testJson.getStructureTest(), HttpMethod.PATCH);
     }
 
     @PutMapping(ApiRoutes.PROJECT_BASE_PATH + "/{projectid}/tests")
     @Roles({UserRole.teacher, UserRole.student})
     public ResponseEntity<?> putTests(
-            @RequestParam(name = "dockerimage", required = false) String dockerImage,
-            @RequestParam(name = "dockerscript", required = false) String dockerTest,
-            @RequestParam(name = "dockertemplate", required = false) String dockerTemplate,
-            @RequestParam(name = "structuretest", required = false) String structureTest,
+            @RequestBody TestUpdateJson testJson,
             @PathVariable("projectid") long projectId,
             Auth auth) {
-        return alterTests(projectId, auth.getUserEntity(), dockerImage, dockerTest, dockerTemplate, structureTest, HttpMethod.PUT);
+        return alterTests(projectId, auth.getUserEntity(), testJson.getDockerImage(), testJson.getDockerScript(),
+            testJson.getDockerTemplate(), testJson.getStructureTest(), HttpMethod.PUT);
     }
 
 

--- a/backend/app/src/main/java/com/ugent/pidgeon/model/json/TestUpdateJson.java
+++ b/backend/app/src/main/java/com/ugent/pidgeon/model/json/TestUpdateJson.java
@@ -1,0 +1,49 @@
+package com.ugent.pidgeon.model.json;
+
+public class TestUpdateJson {
+  private String dockerImage;
+  private String dockerScript;
+  private String dockerTemplate;
+  private String structureTest;
+
+  public TestUpdateJson(String dockerImage, String dockerScript, String dockerTemplate, String structureTest) {
+    this.dockerImage = dockerImage;
+    this.dockerScript = dockerScript;
+    this.dockerTemplate = dockerTemplate;
+    this.structureTest = structureTest;
+  }
+
+  public String getDockerImage() {
+    return dockerImage;
+  }
+
+  public void setDockerImage(String dockerImage) {
+    this.dockerImage = dockerImage;
+  }
+
+  public String getDockerScript() {
+    return dockerScript;
+  }
+
+  public void setDockerScript(String dockerScript) {
+    this.dockerScript = dockerScript;
+  }
+
+  public String getDockerTemplate() {
+    return dockerTemplate;
+  }
+
+  public void setDockerTemplate(String dockerTemplate) {
+    this.dockerTemplate = dockerTemplate;
+  }
+
+  public String getStructureTest() {
+    return structureTest;
+  }
+
+  public void setStructureTest(String structureTest) {
+    this.structureTest = structureTest;
+  }
+
+}
+


### PR DESCRIPTION
De PUT/PATCH/POST routes voor de testen werkten nog met een multipart form, dit is nu verandert zodat het met json werkt. Belangrijk is wel dat de tekst deftig geëscaped wordt vooraleer deze in de json gestopt wordt.

Handmatig kan dit escapen bv. met [deze tool](https://www.freeformatter.com/json-escape.html#before-output)
* (deze genereerde bij mij ook wel \r voor de newlines, deze zou ik sowieso wegdoen al zal dit waarschijnlijk geen probleem zijn als je op linux werkt)
