### PR TITLE
Submissions geupdated voor nieuwe docker output

### DIFF
--- a/frontend/src/@types/requests.d.ts
+++ b/frontend/src/@types/requests.d.ts
@@ -68,6 +68,7 @@ export type POST_Requests = {
     visible: boolean;
     maxScore: number;
     deadline: Date | null;
+    visibleAfter: Date | null; 
 }
 
     [ApiRoutes.GROUP_MEMBERS]: {
@@ -264,6 +265,7 @@ export type GET_Responses = {
     email: string
     name: string
     userId: number
+    studentNumber: string | null // Null in case of enrolled/student
   }
   [ApiRoutes.USERS]: {
     name: string
@@ -359,6 +361,7 @@ export type GET_Responses = {
         id: number
         name: string
         surname: string
+        studentNumber: string | null // Null in case of enrolled/student
     },
     [ApiRoutes.USER_AUTH]: GET_Responses[ApiRoutes.USER],
     [ApiRoutes.USER_COURSES]: {

--- a/frontend/src/@types/requests.d.ts
+++ b/frontend/src/@types/requests.d.ts
@@ -208,7 +208,6 @@ export type GET_Responses = {
     groupId: number
     structureAccepted: boolean,
     dockerStatus: DockerStatus,
-    dockerAccepted: boolean
     submissionTime: Timestamp
     projectUrl: ApiRoutes.PROJECT
     groupUrl: ApiRoutes.GROUP

--- a/frontend/src/@types/requests.d.ts
+++ b/frontend/src/@types/requests.d.ts
@@ -169,7 +169,8 @@ type SubTest = {
   correct: string,  // verwachte output
   output: string,  // gegenereerde output
   required: boolean,  //  of de test verplicht is
-  succes: boolean, // of de test verplicht is
+  //FIXME: typo, moet success zijn ipv succes
+  succes: boolean, // of de test geslaagd is
 }
 
 type DockerFeedback = {

--- a/frontend/src/i18n/en/translation.json
+++ b/frontend/src/i18n/en/translation.json
@@ -185,10 +185,12 @@
 
   "submission": {
     "submission": "Submission",
+    "running": "Running tests",
     "submittedFiles": "Submitted files:",
     "structuretest": "Structure test results:",
-    "dockertest": "Docker test results:",
-    "dockertestAborted": "Docker test aborted. Try again later.",
+    "dockertest": "Test results:",
+    "downloadSubmission": "Download submission",
+    "dockertestAborted": "Tests aborted. Try again later.",
     "success": "succeeded",
     "failed": "failed",
     "expected": "Expected output:",

--- a/frontend/src/i18n/en/translation.json
+++ b/frontend/src/i18n/en/translation.json
@@ -189,6 +189,8 @@
     "structuretest": "Structure test results:",
     "dockertest": "Docker test results:",
     "dockertestAborted": "Docker test aborted. Try again later.",
+    "success": "succeeded",
+    "failed": "failed",
     "status": {
       "accepted": "All tests succeeded.",
       "failed": "Some tests failed."

--- a/frontend/src/i18n/en/translation.json
+++ b/frontend/src/i18n/en/translation.json
@@ -191,6 +191,8 @@
     "dockertestAborted": "Docker test aborted. Try again later.",
     "success": "succeeded",
     "failed": "failed",
+    "expected": "Expected output:",
+    "received": "Received output:",
     "status": {
       "accepted": "All tests succeeded.",
       "failed": "Some tests failed."

--- a/frontend/src/i18n/en/translation.json
+++ b/frontend/src/i18n/en/translation.json
@@ -188,6 +188,7 @@
     "submittedFiles": "Submitted files:",
     "structuretest": "Structure test results:",
     "dockertest": "Docker test results:",
+    "dockertestAborted": "Docker test aborted. Try again later.",
     "status": {
       "accepted": "All tests succeeded.",
       "failed": "Some tests failed."

--- a/frontend/src/i18n/nl/translation.json
+++ b/frontend/src/i18n/nl/translation.json
@@ -195,6 +195,8 @@
     "dockertestAborted": "Dockertest afgebroken. Probeer het later nog eens.",
     "success": "Geslaagd",
     "failed": "Niet geslaagd",
+    "expected": "Vewachte output:",
+    "received": "Ontvangen output:",
     "status": {
       "accepted": "Alle testen geslaagd.",
       "failed": "Sommige testen niet geslaagd."

--- a/frontend/src/i18n/nl/translation.json
+++ b/frontend/src/i18n/nl/translation.json
@@ -190,16 +190,18 @@
   "submission": {
     "submission": "Indiening",
     "submittedFiles": "Ingediende bestanden:",
+    "running": "Testen uitvoeren...",
     "structuretest": "Resultaten structuurtest:",
     "dockertest": "Resultaten dockertest:",
-    "dockertestAborted": "Dockertest afgebroken. Probeer het later nog eens.",
+    "downloadSubmission": "Download indiening",
+    "dockertestAborted": "Testen afgebroken. Probeer het later nog eens.",
     "success": "Geslaagd",
     "failed": "Niet geslaagd",
     "expected": "Vewachte output:",
     "received": "Ontvangen output:",
     "status": {
-      "accepted": "Alle testen geslaagd.",
-      "failed": "Sommige testen niet geslaagd."
+      "accepted": "Alle testen zijn geslaagd.",
+      "failed": "Sommige testen zijn niet geslaagd."
     }
   },
 

--- a/frontend/src/i18n/nl/translation.json
+++ b/frontend/src/i18n/nl/translation.json
@@ -192,6 +192,7 @@
     "submittedFiles": "Ingediende bestanden:",
     "structuretest": "Resultaten structuurtest:",
     "dockertest": "Resultaten dockertest:",
+    "dockertestAborted": "Dockertest afgebroken. Probeer het later nog eens.",
     "status": {
       "accepted": "Alle testen geslaagd.",
       "failed": "Sommige testen niet geslaagd."

--- a/frontend/src/i18n/nl/translation.json
+++ b/frontend/src/i18n/nl/translation.json
@@ -193,6 +193,8 @@
     "structuretest": "Resultaten structuurtest:",
     "dockertest": "Resultaten dockertest:",
     "dockertestAborted": "Dockertest afgebroken. Probeer het later nog eens.",
+    "success": "Geslaagd",
+    "failed": "Niet geslaagd",
     "status": {
       "accepted": "Alle testen geslaagd.",
       "failed": "Sommige testen niet geslaagd."

--- a/frontend/src/pages/project/components/SubmissionStatusTag.tsx
+++ b/frontend/src/pages/project/components/SubmissionStatusTag.tsx
@@ -18,7 +18,7 @@ export function createStatusBitVector(submission: GET_Responses[ApiRoutes.SUBMIS
   if(!submission.structureAccepted){
     status |= SubmissionStatus.STRUCTURE_REJECTED
   }
-  if(!submission.dockerAccepted){
+  if(!submission.dockerFeedback.allowed){
     status |= SubmissionStatus.DOCKER_REJECTED
   }
   if(status === 0){

--- a/frontend/src/pages/submission/components/SubmissionCard.tsx
+++ b/frontend/src/pages/submission/components/SubmissionCard.tsx
@@ -71,11 +71,9 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
         }
     }
 
-    const tmpSubTests = [{testName: "test1", testDescription: "test1", succes: true, correct: "correct", output: "correct"}, {testName: "test2", testDescription: "test2", succes: false, correct: "correct", output: "incorrect"}]
-
     const TestResults: React.FC<SubTest[]> = ( subTests ) => (
         <Collapse style={{marginTop: 8}}>
-            {tmpSubTests.map((test, index) => {
+            {subTests.map((test, index) => {
             const successText = test.succes ? t("submission.success") : t("submission.failed");
             const successType = test.succes ? 'success' : 'danger';
             return (
@@ -84,9 +82,9 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
                     header={<Typography.Text type={successType}>{`${test.testName}: ${successText}`}</Typography.Text>}
                 >
                     <Typography.Paragraph>{test.testDescription}</Typography.Paragraph>
-                    <Typography.Title level={5}>Expected Output:</Typography.Title>
+                    <Typography.Title level={5}>{t("submission.expected")}</Typography.Title>
                     <Typography.Text>{test.correct}</Typography.Text>
-                    <Typography.Title level={5}>Actual Output:</Typography.Title>
+                    <Typography.Title level={5}>{t("submission.received")}</Typography.Title>
                     <Typography.Text>{test.output}</Typography.Text>
                 </Collapse.Panel>
             );

--- a/frontend/src/pages/submission/components/SubmissionCard.tsx
+++ b/frontend/src/pages/submission/components/SubmissionCard.tsx
@@ -1,189 +1,80 @@
-import {Card, Spin, theme, Input, Button, Typography} from "antd"
-import {useTranslation} from "react-i18next"
-import {GET_Responses} from "../../../@types/requests"
-import {ApiRoutes} from "../../../@types/requests"
-import {ArrowLeftOutlined} from "@ant-design/icons"
-import {useNavigate} from "react-router-dom"
+import { Card, Spin, theme, Input, Button, Typography } from "antd"
+import { useTranslation } from "react-i18next"
+import { GET_Responses } from "../../../@types/requests"
+import { ApiRoutes } from "../../../@types/requests"
+import { ArrowLeftOutlined, DownloadOutlined } from "@ant-design/icons"
+import { useNavigate } from "react-router-dom"
 import "@fontsource/jetbrains-mono"
 import apiCall from "../../../util/apiFetch"
-import {Collapse} from "antd"
-import { SubTest } from "../../../@types/requests"
-import { useEffect, useState } from "react"
+import SubmissionContent from "./SubmissionCardContent"
 
 export type SubmissionType = GET_Responses[ApiRoutes.SUBMISSION]
 
-const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) => {
-    const {token} = theme.useToken()
-    const {t} = useTranslation()
-    const navigate = useNavigate()
-    const [filename, setFilename] = useState<String | null>(null)
+const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({ submission }) => {
+  const { token } = theme.useToken()
+  const { t } = useTranslation()
+  const navigate = useNavigate()
 
-    useEffect(() => {
-        const getFileName = async () => {
-            //mss is er een betere manier om de filename te krijgen, dit werkt maar kan mss langzaam zijn met hele grote files/directories
-            try {
-                const response = await apiCall.get(submission.fileUrl, undefined, undefined, {
-                    responseType: 'blob',
-                    transformResponse: [(data) => data],
-                });
-                const contentDisposition = response.headers['content-disposition'];
-                if (contentDisposition) {
-                    const fileNameMatch = contentDisposition.match(/filename=([^;]+)/);
-                    console.log(fileNameMatch);
-                    if (fileNameMatch && fileNameMatch[1]) {
-                        setFilename(fileNameMatch[1]); // use the filename from the headers
-                    }
-                }
-            } catch (err) {
-                console.log(err);
-                setFilename(null);
-            }
-        };
-    
-        getFileName();
-    }, [submission]);
-
-    const downloadSubmission = async () => {
-        try {
-            const response = await apiCall.get(submission.fileUrl, undefined, undefined, {
-                responseType: 'blob',
-                transformResponse: [(data) => data],
-            });
-            console.log(response);
-            const url = window.URL.createObjectURL(new Blob([response.data]));
-            const link = document.createElement('a');
-            link.href = url;
-            const contentDisposition = response.headers['content-disposition'];
-            console.log(contentDisposition);
-            let fileName = 'file.zip'; // default filename
-            if (contentDisposition) {
-                const fileNameMatch = contentDisposition.match(/filename=([^;]+)/);
-                console.log(fileNameMatch);
-                if (fileNameMatch && fileNameMatch[1]) {
-                    fileName = fileNameMatch[1]; // use the filename from the headers
-                }
-            }
-            link.setAttribute('download', fileName);
-            document.body.appendChild(link);
-            link.click();
-        } catch (err) {
-            console.error(err);
+  
+  const downloadSubmission = async () => {
+    try {
+      const response = await apiCall.get(submission.fileUrl, undefined, undefined, {
+        responseType: "blob",
+        transformResponse: [(data) => data],
+      })
+      console.log(response)
+      const url = window.URL.createObjectURL(new Blob([response.data]))
+      const link = document.createElement("a")
+      link.href = url
+      const contentDisposition = response.headers["content-disposition"]
+      console.log(contentDisposition)
+      let fileName = "file.zip" // default filename
+      if (contentDisposition) {
+        const fileNameMatch = contentDisposition.match(/filename=([^;]+)/)
+        console.log(fileNameMatch)
+        if (fileNameMatch && fileNameMatch[1]) {
+          fileName = fileNameMatch[1] // use the filename from the headers
         }
+      }
+      link.setAttribute("download", fileName)
+      document.body.appendChild(link)
+      link.click()
+    } catch (err) {
+      console.error(err)
     }
+  }
 
-    const TestResults: React.FC<SubTest[]> = ( subTests ) => (
-        <Collapse style={{marginTop: 8}}>
-            {subTests.map((test, index) => {
-            const successText = test.succes ? t("submission.success") : t("submission.failed");
-            const successType = test.succes ? 'success' : 'danger';
-            return (
-                <Collapse.Panel
-                    key={index}
-                    header={<Typography.Text type={successType}>{`${test.testName}: ${successText}`}</Typography.Text>}
-                >
-                    <Typography.Paragraph>{test.testDescription}</Typography.Paragraph>
-                    <Typography.Title level={5}>{t("submission.expected")}</Typography.Title>
-                    <Typography.Text>{test.correct}</Typography.Text>
-                    <Typography.Title level={5}>{t("submission.received")}</Typography.Title>
-                    <Typography.Text>{test.output}</Typography.Text>
-                </Collapse.Panel>
-            );
-        })}
-        </Collapse>
-    );
 
-    return (
-        <Card
-            styles={{
-                header: {
-                    background: token.colorPrimaryBg,
-                },
-                title: {
-                    fontSize: "1.1em",
-                },
-            }}
-            type="inner"
-            title={
-                <span>
+  return (
+    <Card
+      styles={{
+        header: {
+          background: token.colorPrimaryBg,
+        },
+        title: {
+          fontSize: "1.1em",
+        },
+      }}
+      type="inner"
+      title={
+        <span>
           <Button
-              onClick={() => navigate(-1)}
-              type="text"
-              style={{marginRight: 16}}
+            onClick={() => navigate(-1)}
+            type="text"
+            style={{ marginRight: 16 }}
           >
-            <ArrowLeftOutlined/>
+            <ArrowLeftOutlined />
           </Button>
-                    {t("submission.submission")}
+          {t("submission.submission")}
         </span>
-            }
-        >
-            {t("submission.submittedFiles")}
-
-            <ul style={{listStyleType: "none"}}>
-                <li>
-                    <Button
-                        type="link"
-                        style={{padding: 0}}
-                        onClick={downloadSubmission}
-                    >
-                        {filename === null ? <Spin></Spin> : <u>{filename}</u>}
-                    </Button>
-                </li>
-            </ul>
-
-            {t("submission.structuretest")}
-
-            <ul style={{listStyleType: "none"}}>
-                <li>
-                    <Typography.Text
-                        type={submission.structureAccepted ? "success" : "danger"}>{submission.structureAccepted ? t("submission.status.accepted") : t("submission.status.failed")}</Typography.Text>
-                    {submission.structureAccepted ? null : (
-            <div>
-              {submission.structureFeedback === null ? (
-                <Spin />
-              ) : (
-                <Input.TextArea
-                  readOnly
-                  value={submission.structureFeedback}
-                  style={{ width: "100%", overflowX: "auto", overflowY: "auto", resize: "none", fontFamily: "Jetbrains Mono", marginTop: 8 }}
-                  rows={4}
-                  autoSize={{ minRows: 4, maxRows: 8 }}
-                />
-              )}
-            </div>
-          )}
-                </li>
-            </ul>
-
-            {submission.dockerStatus !== "running" && submission.dockerFeedback.type === "NONE" ? null : (<>
-
-            {t("submission.dockertest")}
-
-            <ul style={{listStyleType: "none"}}>
-                <li>
-                    {submission.dockerStatus === "running" ? (
-                        <Spin/>
-                    ) : (submission.dockerStatus === "aborted" ? t("submission.dockertestAborted") : <>
-                    <Typography.Text
-                        type={submission.dockerFeedback.allowed ? "success" : "danger"}>{submission.dockerFeedback.allowed ? t("submission.status.accepted") : t("submission.status.failed")}</Typography.Text>
-                    {submission.dockerFeedback.type === "SIMPLE" ? (
-                    <div>
-                        <Input.TextArea
-                        readOnly
-                        value={submission.dockerFeedback.feedback}
-                        style={{ width: "100%", overflowX: "auto", overflowY: "auto", resize: "none", fontFamily: "Jetbrains Mono", marginTop: 8 }}
-                        rows={4}
-                        autoSize={{ minRows: 4, maxRows: 16 }}
-                        />
-                    </div>
-                    ) : (submission.dockerFeedback.type === "TEMPLATE" ? (
-                        TestResults(submission.dockerFeedback.feedback.subtests)
-                    ) : null)}
-                    </>)}
-                </li>
-            </ul>
-            </>)}
-        </Card>
-    )
+      }
+      extra={
+        <Button type="primary" icon={<DownloadOutlined/>} onClick={downloadSubmission}>{t("submission.downloadSubmission")}</Button>
+      }
+    >
+      <SubmissionContent submission={submission} />
+    </Card>
+  )
 }
 
 export default SubmissionCard

--- a/frontend/src/pages/submission/components/SubmissionCard.tsx
+++ b/frontend/src/pages/submission/components/SubmissionCard.tsx
@@ -16,7 +16,6 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
     const {t} = useTranslation()
     const navigate = useNavigate()
 
-    //TODO: correcte file download
     const downloadSubmission = async () => {
         try {
             const response = await apiCall.get(submission.fileUrl, undefined, undefined, {
@@ -45,9 +44,11 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
         }
     }
 
+    const tmpSubTests = [{testName: "test1", testDescription: "test1", succes: true, correct: "correct", output: "correct"}, {testName: "test2", testDescription: "test2", succes: false, correct: "correct", output: "incorrect"}]
+
     const TestResults: React.FC<SubTest[]> = ( subTests ) => (
-        <Collapse>
-            {subTests.map((test, index) => {
+        <Collapse style={{marginTop: 8}}>
+            {tmpSubTests.map((test, index) => {
             const successText = test.succes ? 'SUCCESS' : 'FAILURE';
             const successType = test.succes ? 'success' : 'danger';
             return (
@@ -66,7 +67,6 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
         </Collapse>
     );
 
-    const feedback = "TODO: feedback"
     return (
         <Card
             styles={{
@@ -129,11 +129,9 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
                 </li>
             </ul>
 
-            {submission.dockerStatus === "no_test" ? null : (<>
+            {submission.dockerStatus !== "running" && submission.dockerFeedback.type === "NONE" ? null : (<>
 
             {t("submission.dockertest")}
-
-            
 
             <ul style={{listStyleType: "none"}}>
                 <li>
@@ -141,7 +139,7 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
                         <Spin/>
                     ) : (submission.dockerStatus === "aborted" ? t("submission.dockertestAborted") : <>
                     <Typography.Text
-                        type={submission.dockerAccepted ? "success" : "danger"}>{submission.dockerAccepted ? t("submission.status.accepted") : t("submission.status.failed")}</Typography.Text>
+                        type={submission.dockerFeedback.allowed ? "success" : "danger"}>{submission.dockerFeedback.allowed ? t("submission.status.accepted") : t("submission.status.failed")}</Typography.Text>
                     {submission.dockerFeedback.type === "SIMPLE" ? (
                     <div>
                         <Input.TextArea
@@ -152,9 +150,9 @@ const SubmissionCard: React.FC<{ submission: SubmissionType }> = ({submission}) 
                         autoSize={{ minRows: 4, maxRows: 16 }}
                         />
                     </div>
-                    ) : (submission.dockerFeedback.type === "NONE" ? (
+                    ) : (submission.dockerFeedback.type === "TEMPLATE" ? (
                         TestResults(submission.dockerFeedback.feedback.subtests)
-                    ) : (submission.dockerFeedback.type))}
+                    ) : null)}
                     </>)}
                 </li>
             </ul>

--- a/frontend/src/pages/submission/components/SubmissionCardContent.tsx
+++ b/frontend/src/pages/submission/components/SubmissionCardContent.tsx
@@ -1,0 +1,100 @@
+import { Collapse, Flex, Input, Spin, Typography } from "antd"
+import { useTranslation } from "react-i18next"
+import { SubTest } from "../../../@types/requests"
+import { FC } from "react"
+import { SubmissionType } from "./SubmissionCard"
+
+const SubmissionContent: FC<{ submission: SubmissionType }> = ({ submission }) => {
+  const { t } = useTranslation()
+
+  const TestResults: React.FC<SubTest[]> = (subTests) => (
+    <Collapse style={{ marginTop: 8 }}>
+      {subTests.map((test, index) => {
+        const successText = test.succes ? t("submission.success") : t("submission.failed")
+        const successType = test.succes ? "success" : "danger"
+        return (
+          <Collapse.Panel
+            key={index}
+            header={<Typography.Text type={successType}>{`${test.testName}: ${successText}`}</Typography.Text>}
+          >
+            <Typography.Paragraph type="secondary">{test.testDescription}</Typography.Paragraph>
+            <Flex justify="space-around" gap="1rem">
+              <div style={{width:"100%"}}>
+                <Typography.Title level={5}>{t("submission.expected")}</Typography.Title>
+                <Input.TextArea autoSize={{ minRows: 3, maxRows: 20 }} readOnly value={test.correct} style={{ width: "100%", overflowX: "auto", overflowY: "auto", resize: "none", fontFamily: "Jetbrains Mono" }} />
+              </div>
+              <div style={{width:"100%"}}>
+                <Typography.Title level={5}>{t("submission.received")}</Typography.Title>
+                <Input.TextArea autoSize={{ minRows: 3, maxRows: 20 }} readOnly value={test.output} style={{ width: "100%", overflowX: "auto", overflowY: "auto", resize: "none", fontFamily: "Jetbrains Mono" }} />
+
+              </div>
+            </Flex>
+          </Collapse.Panel>
+        )
+      })}
+    </Collapse>
+  )
+  if (submission.dockerStatus === "aborted") return <Typography.Text type="danger">{t("submission.dockertestAborted")}</Typography.Text>
+  if (submission.dockerStatus === "running")
+    return (
+      <div style={{ textAlign: "center" }}>
+        <br />
+        <Spin size="large" />
+        <br />
+        <br />
+        <Typography.Text type="secondary">{t("submission.running")}</Typography.Text>
+        <br />
+        <br />
+      </div>
+    )
+  return (
+    <>
+      {t("submission.structuretest")}
+
+      {submission.dockerStatus === "no_test" && <ul style={{ listStyleType: "none" }}>
+        <li>
+          <Typography.Text type={submission.structureAccepted ? "success" : "danger"}>{submission.structureAccepted ? t("submission.status.accepted") : t("submission.status.failed")}</Typography.Text>
+          {submission.structureAccepted ? null : (
+            <div>
+              {submission.structureFeedback === null ? (
+                <Spin />
+              ) : (
+                <Input.TextArea
+                  readOnly
+                  value={submission.structureFeedback}
+                  style={{ width: "100%", overflowX: "auto", overflowY: "auto", resize: "none", fontFamily: "Jetbrains Mono", marginTop: 8 }}
+                  autoSize={{ minRows: 4, maxRows: 128 }}
+                />
+              )}
+            </div>
+          )}
+        </li>
+      </ul>}
+
+      {submission.dockerStatus === "finished" && (
+        <ul style={{ listStyleType: "none" }}>
+          <li>
+            <>
+              <Typography.Text type={submission.dockerFeedback.allowed ? "success" : "danger"}>{submission.dockerFeedback.allowed ? t("submission.status.accepted") : t("submission.status.failed")}</Typography.Text>
+              {submission.dockerFeedback.type === "SIMPLE" ? (
+                <div>
+                  <Input.TextArea
+                    readOnly
+                    value={submission.dockerFeedback.feedback}
+                    style={{ width: "100%", overflowX: "auto", overflowY: "auto", resize: "none", fontFamily: "Jetbrains Mono", marginTop: 8 }}
+                    
+                    autoSize={{ minRows: 4, maxRows: 128 }}
+                  />
+                </div>
+              ) : submission.dockerFeedback.type === "TEMPLATE" ? (
+                TestResults(submission.dockerFeedback.feedback.subtests)
+              ) : null}
+            </>
+          </li>
+        </ul>
+      )}
+    </>
+  )
+}
+
+export default SubmissionContent


### PR DESCRIPTION
Submission pagina is nu aangepast zodat het de nieuwe docker output ondersteunt.

Volgende snippet code kan nog problemen veroorzaken:

```javascript
    useEffect(() => {
        const getFileName = async () => {
            //mss is er een betere manier om de filename te krijgen, dit werkt maar kan mss langzaam zijn met hele grote files/directories
            try {
                const response = await apiCall.get(submission.fileUrl, undefined, undefined, {
                    responseType: 'blob',
                    transformResponse: [(data) => data],
                });
                const contentDisposition = response.headers['content-disposition'];
                if (contentDisposition) {
                    const fileNameMatch = contentDisposition.match(/filename=([^;]+)/);
                    console.log(fileNameMatch);
                    if (fileNameMatch && fileNameMatch[1]) {
                        setFilename(fileNameMatch[1]); // use the filename from the headers
                    }
                }
            } catch (err) {
                console.log(err);
                setFilename(null);
            }
        };
    
        getFileName();
    }, [submission]);
```

Deze code snippet vraagt de filename op van de ingediende file, maar volgens mij downloadt het ook de hele file (dit stuk code is gekopieerd van de file download code). Misschien is het een goed idee om dit anders te doen om alleen de filename op te vragen, maar weet niet hoe. Tips zijn welkom :)