### PR TITLE
fix graphical bug with "en" appearing under the globe icon

### DIFF
--- a/frontend/src/components/LanguageDropdown.tsx
+++ b/frontend/src/components/LanguageDropdown.tsx
@@ -26,7 +26,7 @@ const LanguageDropdown = () => {
 
 
   return <Dropdown menu={{ items, onClick: languageChange }}>
-    <Typography.Text style={{ cursor: "pointer", width: "5rem" }}>
+    <Typography.Text style={{ cursor: "pointer", width: "6rem" }}>
       <GlobalOutlined /> {app.language}
     </Typography.Text>
   </Dropdown>


### PR DESCRIPTION
Heel kleine PR, heb de breedte van de tekst component van de language dropdown veranderd van 5rem naar 6rem